### PR TITLE
Add finish-build-watchface workflow

### DIFF
--- a/.github/workflows/finish-build-watchface.yml
+++ b/.github/workflows/finish-build-watchface.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build Watch Face Format Codelab - Finish
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./codelab-watch-face-format/finish
+
+      - name: Build watchface
+        working-directory: ./codelab-watch-face-format/finish
+        run: ./gradlew :watchface:assembleDebug


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to automate the build process for the watch face format codelab's "finish" directory.

The workflow is triggered on:

- workflow_dispatch
- pushes to the main branch
- pull requests targeting the main branch

The workflow performs the following steps:

- Checks out the code.
- Sets up JDK 17 using Zulu.
- Sets up Gradle.
- Makes the gradlew executable.
- Builds the watchface using the `watchface:assembleDebug` Gradle task.